### PR TITLE
Update thor-setup.yml

### DIFF
--- a/thor.psi.ch/default/thor-setup.yml
+++ b/thor.psi.ch/default/thor-setup.yml
@@ -6,7 +6,7 @@ hostname: lms-login.psi.ch
 label: thor
 mpiprocs_per_machine: 48
 mpirun_command: mpirun -np {tot_num_mpiprocs}
-prepend_text: ''
+prepend_text: 'export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK'
 scheduler: core.slurm
 shebang: "#!/bin/bash"
 transport: core.ssh


### PR DESCRIPTION
This automatically sets the threads to be consistend with requested cpus_per_task. 

useful in case we want to use thread-parallelized codes (e.g. yambo).

In this way we can avoid to hardcode 1 thread in `/mnt/home/software/qe/7.3-ioapi/source.sh`